### PR TITLE
Added link of Angular Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Everything you need to learn in chronological order to become a professional Ang
 - [Angular In Depth - Advanced understanding of inner workings](https://blog.angularindepth.com/)
 - [Netanel Basal - Advanced Practical Tutorials](https://netbasal.com/@NetanelBasal)
 - [Full Stack Contacts Book example app (Components, Services, Routing, Http, Forms, Lazy loading, Sockets, NGRX State management, NGRX HTTP+Socket.IO Side Effects management, NGRX Entity management...)](https://github.com/avatsaev/angular-contacts-app-example)
+- [Angular Developer Roadmap (Complete guide to become Angular Developer...)](https://roadmap.sh/angular)
 
 
 


### PR DESCRIPTION
Hi @avatsaev,

I came across your repository [angular-learning-resources](https://github.com/avatsaev/angular-learning-resources) and found it to be a valuable resource for Angular enthusiasts.

While browsing through the repository, I noticed that it was missing links to the most famous structured guides such as the ["Angular Developer Roadmap"](https://roadmap.sh/angular). I took the initiative to submit a ["Pull Request"](https://github.com/avatsaev/angular-learning-resources/pull/9) adding it in.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz